### PR TITLE
Limit to one toast at a time

### DIFF
--- a/src/context/toastcontext/ToastContext.tsx
+++ b/src/context/toastcontext/ToastContext.tsx
@@ -86,11 +86,17 @@ export const Toasts = () => {
     }
 
     const toast = { ...props, id, timer };
-    setToasts((v) => [...v, toast]);
+
+    setToasts((v) => {
+      v.forEach((t) => clearTimeout(t.timer));
+      return [toast];
+    });
+
     return toast;
   };
 
   clearToastRef.current = (toast) => {
+    clearTimeout(toast.timer);
     setToasts((v) => v.filter((t) => t !== toast));
   };
 


### PR DESCRIPTION
## Summary
- ensure pushing a new toast replaces the previous one
- clear active toast timers when clearing or replacing toasts

## Testing
- `npm test --silent`
- `npm run tsup --silent` *(fails: tsup not found)*

------
https://chatgpt.com/codex/tasks/task_e_685579c1592c83249bad05d87f71322e